### PR TITLE
Reduce CPU usage during idling

### DIFF
--- a/openrr-nav-viewer/src/bevy_app.rs
+++ b/openrr-nav-viewer/src/bevy_app.rs
@@ -1,4 +1,7 @@
-use bevy::prelude::*;
+use bevy::{
+    prelude::*,
+    winit::{UpdateMode, WinitSettings},
+};
 use bevy_egui::{
     egui::{
         self,
@@ -98,11 +101,25 @@ impl BevyAppNav {
         let ui_checkboxes = UiCheckboxes::default();
         let displayed_arrows = DisplayedArrows::default();
 
+        // Refs:
+        // - https://github.com/bevyengine/bevy/blob/HEAD/examples/window/low_power.rs
+        // - https://docs.rs/bevy/latest/bevy/winit/enum.UpdateMode.html
+        let winit_settings = WinitSettings {
+            focused_mode: UpdateMode::Reactive {
+                max_wait: std::time::Duration::from_secs_f64(1.0 / 20.0), // 20Hz,
+            },
+            unfocused_mode: UpdateMode::Reactive {
+                max_wait: std::time::Duration::from_secs_f64(1.0 / 20.0), // 20Hz,
+            },
+            ..Default::default()
+        };
+
         self.app
             .insert_resource(nav)
             .insert_resource(map_type)
             .insert_resource(ui_checkboxes)
             .insert_resource(displayed_arrows)
+            .insert_resource(winit_settings)
             .add_plugins(user_plugin)
             .add_plugins(EguiPlugin)
             .add_systems(Update, ui_system)


### PR DESCRIPTION
~~(The first commit is from #22, and the second commit is from #25)~~

cc #19 

before/after(busy):
<img width="368" alt="ss" src="https://github.com/openrr/grid_map/assets/43724913/422b5d67-e115-4a03-936b-0036ed910df8">

after(idling):
<img width="229" alt="gm20hz" src="https://github.com/openrr/grid_map/assets/43724913/5943a0ab-2037-4642-977d-b62b1088f986">

FYI, when I increase max_wait from 20hz to 30hz, CPU usage during idling will be increased to about 70%.

<img width="377" alt="gm30hz" src="https://github.com/openrr/grid_map/assets/43724913/020f96d6-05c1-47a6-9755-ea5b238d4c93">


Refs:
- https://github.com/bevyengine/bevy/blob/HEAD/examples/window/low_power.rs
- https://docs.rs/bevy/latest/bevy/winit/enum.UpdateMode.html