### PR TITLE
Remove yaml-rust dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ thiserror = "1"
 tokio = "1"
 tonic = "0.10"
 tonic-build = "0.10"
-yaml-rust = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 

--- a/grid_map/Cargo.toml
+++ b/grid_map/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 [dependencies]
 image.workspace = true
 thiserror.workspace = true
-yaml-rust.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 

--- a/grid_map/src/error.rs
+++ b/grid_map/src/error.rs
@@ -8,8 +8,6 @@ pub enum Error {
     IoError(#[from] std::io::Error),
     #[error("image crate: {0}")]
     ImageError(#[from] image::ImageError),
-    #[error("yaml scan error: {0}")]
-    YamlScanError(#[from] yaml_rust::ScanError),
     #[error("yaml parse error: {0}")]
     YamlParseError(#[from] serde_yaml::Error),
     #[error("out of range grid: {0:?}")]


### PR DESCRIPTION
close #30 

In the test data map.yaml, `origin` is defined as a 3-element array, whereas in the source code it is treated as 2 elements. This is causing the CI run failure.

https://github.com/openrr/grid_map/blob/0f6020d46fd270721dc8d811f196ed574b6b83fe/grid_map/test/map.yaml#L3

https://github.com/openrr/grid_map/blob/0f6020d46fd270721dc8d811f196ed574b6b83fe/grid_map/src/utils.rs#L17-L25

https://github.com/openrr/grid_map/blob/beb25d1dfc1247ec20c5096cb4e0e302bb8b871e/grid_map/src/position.rs#L3-L9